### PR TITLE
Add Release Workflow

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,0 +1,28 @@
+# This workflow publishes the package to TestPyPi when a new release is created.
+name: Upload Python Package
+on:
+  release:
+    types: [published]
+permissions:
+  contents: read
+jobs:
+  # Build the package, then publish it.
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Code
+      uses: actions/checkout@v4.1.7
+    # By default, this will look for the .python-version file to determine which to install.
+    - name: Set up Python
+      uses: actions/setup-python@v5.1.0
+    - name: Install Dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install poetry
+    # Poetry does not normally know to look for TestPyPi
+    - name: Configure Test PyPi Access
+      run: poetry config repositories.testpypi https://test.pypi.org/legacy/
+    - name: Build Package
+      run: poetry build
+    - name: Publish Package
+      run: poetry publish --repository=testpypi --username=__token__ --password=${{ secrets.TEST_PYPI_TOKEN }}


### PR DESCRIPTION
Adds a workflow that will build and push the package to TestPyPi every time a Release is released.

Closes #8 